### PR TITLE
Normalize instruction formatting in assembly files

### DIFF
--- a/src/confirm.asm
+++ b/src/confirm.asm
@@ -31,31 +31,42 @@ SECTION "ConfirmModule", ROM1[$4500]
 
 Entry_Confirm:
     ; Verificar que haya datos en los buffers de entrada
-    ld hl, AddressBuf, ld a, [hl], or a, jr z, .no_data
-    ld hl, AmountBuf,  ld a, [hl], or a, jr z, .no_data
+    ld hl, AddressBuf
+    ld a, [hl]
+    or a
+    jr z, .no_data
+    ld hl, AmountBuf
+    ld a, [hl]
+    or a
+    jr z, .no_data
 
     call DrawConfirmScreen
 .wait_input:
     call ReadJoypadWithDebounce
     ld a, [JoyState]
-    bit BUTTON_A_BIT, a, jr nz, .confirm
-    bit BUTTON_B_BIT, a, jr nz, .cancel
+    bit BUTTON_A_BIT, a
+    jr nz, .confirm
+    bit BUTTON_B_BIT, a
+    jr nz, .cancel
     jr .wait_input
 
 .confirm:
     call PlayBeepConfirm
     call SRAM_LogTransaction
     call ClearInputBuffers ; Limpiar buffers para la siguiente transacción
-    call ShowMessage, SuccessMsg
+    ld hl, SuccessMsg
+    call ShowMessage
     ret
 
 .cancel:
     call PlayBeepNav
-    call ShowMessage, CancelMsg
+    ld hl, CancelMsg
+    call ShowMessage
     ret
 
 .no_data:
-    call ShowMessage, NoDataMsg
+    ld hl, NoDataMsg
+    call ShowMessage
     ret
 
 ; ====================================================================
@@ -63,26 +74,57 @@ Entry_Confirm:
 ; ====================================================================
 DrawConfirmScreen:
     call UI_ClearScreen
-    ld a, 1, ld b, 1, ld c, 18, ld d, 16, call UI_DrawBox
-    ld hl, ConfirmTitle, ld c, 1, ld d, 1, ld e, 18, call UI_PrintInBox
-    ld hl, AddressLabel, ld d, 3, ld e, 2, call UI_PrintStringAtXY
-    ld hl, AddressBuf,   ld d, 4, ld e, 2, call UI_PrintStringAtXY
-    ld hl, AmountLabel,  ld d, 6, ld e, 2, call UI_PrintStringAtXY
-    ld hl, AmountBuf,    ld d, 7, ld e, 2, call UI_PrintStringAtXY
-    ld hl, ConfirmInstr1, ld d, 12, ld e, 2, call UI_PrintStringAtXY
-    ld hl, ConfirmInstr2, ld d, 13, ld e, 2, call UI_PrintStringAtXY
+    ld a, 1
+    ld b, 1
+    ld c, 18
+    ld d, 16
+    call UI_DrawBox
+    ld hl, ConfirmTitle
+    ld c, 1
+    ld d, 1
+    ld e, 18
+    call UI_PrintInBox
+    ld hl, AddressLabel
+    ld d, 3
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, AddressBuf
+    ld d, 4
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, AmountLabel
+    ld d, 6
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, AmountBuf
+    ld d, 7
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, ConfirmInstr1
+    ld d, 12
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, ConfirmInstr2
+    ld d, 13
+    ld e, 2
+    call UI_PrintStringAtXY
     ret
 
 ShowMessage:
     ; Entrada: HL = puntero al mensaje (pasado por pila)
     call UI_ClearScreen
-    ld d, 8, ld e, 2
+    ld d, 8
+    ld e, 2
     call UI_PrintStringAtXY
     ld a, (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT)
     call WaitButton
     ret
 
 ClearInputBuffers:
-    ld hl, AddressBuf, xor a, ld [hl], a
-    ld hl, AmountBuf,  xor a, ld [hl], a
+    ld hl, AddressBuf
+    xor a
+    ld [hl], a
+    ld hl, AmountBuf
+    xor a
+    ld [hl], a
     ret

--- a/src/input.asm
+++ b/src/input.asm
@@ -31,71 +31,149 @@ Entry_Input:
     cp b, jr z, .input_loop
     ld a, b, ld [JoyPrevState], a
 
-    bit BUTTON_LEFT_BIT, b,  jr nz, .handle_left
-    bit BUTTON_RIGHT_BIT, b, jr nz, .handle_right
-    bit BUTTON_A_BIT, b,     jr nz, .handle_a
-    bit BUTTON_B_BIT, b,     jr nz, .handle_b
-    bit BUTTON_START_BIT, b, jr nz, .handle_start
+    bit BUTTON_LEFT_BIT, b
+    jr nz, .handle_left
+    bit BUTTON_RIGHT_BIT, b
+    jr nz, .handle_right
+    bit BUTTON_A_BIT, b
+    jr nz, .handle_a
+    bit BUTTON_B_BIT, b
+    jr nz, .handle_b
+    bit BUTTON_START_BIT, b
+    jr nz, .handle_start
     jr .input_loop
 
 .handle_left:
-    ld a, [InputCursorPos], or a, jr z, .wrap_right, dec a, jr .update_cursor
+    ld a, [InputCursorPos]
+    or a
+    jr z, .wrap_right
+    dec a
+    jr .update_cursor
 .wrap_right: ld a, CharsetLen - 1
 .update_cursor:
-    ld [InputCursorPos], a, call PlayBeepNav, jr .input_loop
+    ld [InputCursorPos], a
+    call PlayBeepNav
+    jr .input_loop
 
 .handle_right:
-    ld a, [InputCursorPos], inc a, cp CharsetLen, jr c, .update_cursor
-    xor a, jr .update_cursor
+    ld a, [InputCursorPos]
+    inc a
+    cp CharsetLen
+    jr c, .update_cursor
+    xor a
+    jr .update_cursor
 
 .handle_a: ; Añadir caracter
-    ld a, [InputLen], ld b, a, ld a, [InputMaxLen], cp b, jr z, .buffer_full
-    ld a, [InputCursorPos], call GetCharsetFromIndex, call Input_AddChar, call PlayBeepConfirm, jr .input_loop
+    ld a, [InputLen]
+    ld b, a
+    ld a, [InputMaxLen]
+    cp b
+    jr z, .buffer_full
+    ld a, [InputCursorPos]
+    call GetCharsetFromIndex
+    call Input_AddChar
+    call PlayBeepConfirm
+    jr .input_loop
 .buffer_full:
-    call PlayBeepError, jr .input_loop
+    call PlayBeepError
+    jr .input_loop
 
 .handle_b: ; Borrar caracter
-    call Input_Backspace, call PlayBeepNav, jr .input_loop
+    call Input_Backspace
+    call PlayBeepNav
+    jr .input_loop
 
 .handle_start: ; Confirmar y salir
-    call PlayBeepConfirm, ret
+    call PlayBeepConfirm
+    ret
 
 ; --- Subrutinas de Lógica ---
 Input_Init:
-    xor a, ld [InputCursorPos], a, ld [InputLen], a
-    ld a, [InputDestBufAddr], ld l, a, ld a, [InputDestBufAddr+1], ld h, a
+    xor a
+    ld [InputCursorPos], a
+    ld [InputLen], a
+    ld a, [InputDestBufAddr]
+    ld l, a
+    ld a, [InputDestBufAddr+1]
+    ld h, a
     ld [hl], 0 ; Asegurar que el buffer de destino empieza vacío
     ret
 
 Input_AddChar: ; Entrada: A = caracter a añadir
-    ld hl, [InputDestBufAddr], ld a, [InputLen], ld c, a, ld b, 0, add hl, bc
-    ld a, [sp+2], ld [hl+], a, xor a, ld [hl], a
-    ld hl, InputLen, inc [hl], ret
+    ld hl, [InputDestBufAddr]
+    ld a, [InputLen]
+    ld c, a
+    ld b, 0
+    add hl, bc
+    ld a, [sp+2]
+    ld [hl+], a
+    xor a
+    ld [hl], a
+    ld hl, InputLen
+    inc [hl]
+    ret
 
 Input_Backspace:
-    ld a, [InputLen], or a, ret z
-    dec [InputLen], ld a, [InputLen], ld c, a, ld b, 0
-    ld hl, [InputDestBufAddr], add hl, bc, xor a, ld [hl], a, ret
+    ld a, [InputLen]
+    or a
+    ret z
+    dec [InputLen]
+    ld a, [InputLen]
+    ld c, a
+    ld b, 0
+    ld hl, [InputDestBufAddr]
+    add hl, bc
+    xor a
+    ld [hl], a
+    ret
 
 GetCharsetFromIndex: ; Entrada: A = índice, Salida: A = caracter
     push hl, bc
-    ld hl, Charset, ld b, 0, ld c, a, add hl, bc, ld a, [hl]
-    pop bc, hl, ret
+    ld hl, Charset
+    ld b, 0
+    ld c, a
+    add hl, bc
+    ld a, [hl]
+    pop bc, hl
+    ret
 
 ; --- Rutina de Dibujo ---
 Input_DrawUI:
-    call UI_ClearScreen, ld a, 1, ld b, 1, ld c, 18, ld d, 16, call UI_DrawBox
+    call UI_ClearScreen
+    ld a, 1
+    ld b, 1
+    ld c, 18
+    ld d, 16
+    call UI_DrawBox
     ; Prompt
-    ld hl, [InputPromptAddr], ld d, 3, ld e, 2, call UI_PrintStringAtXY
+    ld hl, [InputPromptAddr]
+    ld d, 3
+    ld e, 2
+    call UI_PrintStringAtXY
     ; Buffer de entrada
-    ld hl, [InputDestBufAddr], ld d, 5, ld e, 2, call UI_PrintStringAtXY
+    ld hl, [InputDestBufAddr]
+    ld d, 5
+    ld e, 2
+    call UI_PrintStringAtXY
     ; Selector de caracteres
-    ld a, [InputCursorPos], call GetCharsetFromIndex
-    ld d, 8, ld e, 9, call UI_PrintAtXY
-    ld a, '<', ld d, 8, ld e, 8, call UI_PrintAtXY
-    ld a, '>', ld d, 8, ld e, 10, call UI_PrintAtXY
+    ld a, [InputCursorPos]
+    call GetCharsetFromIndex
+    ld d, 8
+    ld e, 9
+    call UI_PrintAtXY
+    ld a, '<'
+    ld d, 8
+    ld e, 8
+    call UI_PrintAtXY
+    ld a, '>'
+    ld d, 8
+    ld e, 10
+    call UI_PrintAtXY
     ; Instrucciones
-    ld hl, InputInstructions, ld d, 12, ld e, 2, call UI_PrintStringAtXY
+    ld hl, InputInstructions
+    ld d, 12
+    ld e, 2
+    call UI_PrintStringAtXY
     ret
 
 ; ====================================================================

--- a/src/link.asm
+++ b/src/link.asm
@@ -17,116 +17,290 @@ EXTERN AddressBuf, AmountBuf
 SECTION "LinkModule", ROM1[$5200]
 
 Entry_LinkTest:
-    ld hl, AddressBuf, ld a, [hl], or a, jr z, .no_data
+    ld hl, AddressBuf
+    ld a, [hl]
+    or a
+    jr z, .no_data
 
     ; --- Flujo de Comunicación ---
     call LinkInit
-    call DrawLinkScreen, .connecting_msg
-    call LinkDetect, jr c, .connection_error
+    ld hl, .connecting_msg
+    call DrawLinkScreen
+    call LinkDetect
+    jr c, .connection_error
 
-    call DrawLinkScreen, .handshake_msg
-    call LinkHandshake, jr c, .handshake_error
-    ld a, 20, call DelayFrames
+    ld hl, .handshake_msg
+    call DrawLinkScreen
+    call LinkHandshake
+    jr c, .handshake_error
+    ld a, 20
+    call DelayFrames
 
-    call DrawLinkScreen, .transmitting_msg
-    call LinkTransmit, jr c, .transmit_error
+    ld hl, .transmitting_msg
+    call DrawLinkScreen
+    call LinkTransmit
+    jr c, .transmit_error
 
-    call DrawLinkScreen, .verifying_msg
-    call LinkVerify, jr c, .verify_error
+    ld hl, .verifying_msg
+    call DrawLinkScreen
+    call LinkVerify
+    jr c, .verify_error
 
     ; --- Éxito ---
-    call DrawLinkScreen, .success_msg, call PlayBeepConfirm, jr .wait_exit
+    ld hl, .success_msg
+    call DrawLinkScreen
+    call PlayBeepConfirm
+    jr .wait_exit
 
     ; --- Manejo de Errores ---
-.connection_error: call DrawLinkScreen, .error_msg_conn, jr .error_common
-.handshake_error:  call DrawLinkScreen, .error_msg_hand, jr .error_common
-.transmit_error:   call DrawLinkScreen, .error_msg_tx,   jr .error_common
-.verify_error:     call DrawLinkScreen, .error_msg_verify, jr .error_common
-.error_common:     call PlayBeepError, jr .wait_exit
-.no_data:          call DrawLinkScreen, .no_data_msg
+.connection_error:
+    ld hl, .error_msg_conn
+    call DrawLinkScreen
+    jr .error_common
+.handshake_error:
+    ld hl, .error_msg_hand
+    call DrawLinkScreen
+    jr .error_common
+.transmit_error:
+    ld hl, .error_msg_tx
+    call DrawLinkScreen
+    jr .error_common
+.verify_error:
+    ld hl, .error_msg_verify
+    call DrawLinkScreen
+    jr .error_common
+.error_common:
+    call PlayBeepError
+    jr .wait_exit
+.no_data:
+    ld hl, .no_data_msg
+    call DrawLinkScreen
 
 .wait_exit:
-    ld a, (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT), call WaitButton, call LinkClose, ret
+    ld a, (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT)
+    call WaitButton
+    call LinkClose
+    ret
 
 ; ====================================================================
 ; Lógica del Protocolo Link (Conceptualizado como una librería interna)
 ; ====================================================================
 
 LinkInit:
-    xor a, ld [rSB], a, ld a, $80, ld [rSC], a
-    ld a, 5, call DelayFrames, ld b, 3
+    xor a
+    ld [rSB], a
+    ld a, $80
+    ld [rSC], a
+    ld a, 5
+    call DelayFrames
+    ld b, 3
 .flush_loop:
-    ld a, $00, call LinkSendByte, ld a, 3, call DelayFrames, dec b, jr nz, .flush_loop, ret
+    ld a, $00
+    call LinkSendByte
+    ld a, 3
+    call DelayFrames
+    dec b
+    jr nz, .flush_loop
+    ret
 
 LinkDetect:
     ld b, MAX_RETRIES
 .detect_loop:
-    ld a, LINK_MAGIC_REQ, call LinkSendByte, jr c, .next_try
-    call LinkReceiveByte, jr c, .next_try
-    cp LINK_MAGIC_ACK, jr z, .success, dec b, jr nz, .detect_loop
-.next_try: dec b, jr nz, .detect_loop
-.error: scf, ret, .success: xor a, ret
+    ld a, LINK_MAGIC_REQ
+    call LinkSendByte
+    jr c, .next_try
+    call LinkReceiveByte
+    jr c, .next_try
+    cp LINK_MAGIC_ACK
+    jr z, .success
+    dec b
+    jr nz, .detect_loop
+.next_try:
+    dec b
+    jr nz, .detect_loop
+.error:
+    scf
+    ret
+.success:
+    xor a
+    ret
 
 LinkHandshake:
-    ld a, LINK_PROTO_VERSION, call LinkSendByte, jr c, .error
-    call LinkReceiveByte, jr c, .error, cp LINK_VERSION_ACK, jr z, .success
-.error: scf, ret, .success: xor a, ret
+    ld a, LINK_PROTO_VERSION
+    call LinkSendByte
+    jr c, .error
+    call LinkReceiveByte
+    jr c, .error
+    cp LINK_VERSION_ACK
+    jr z, .success
+.error:
+    scf
+    ret
+.success:
+    xor a
+    ret
 
 LinkTransmit:
-    call BuildTransactionPayload, jr c, .error
-    ld hl, LinkTxBuffer, call StringLength, ld b, a, ld hl, LinkTxBuffer
-    call LinkSendFrameWithCRC, jr c, .error, xor a, ret
-.error: scf, ret
+    call BuildTransactionPayload
+    jr c, .error
+    ld hl, LinkTxBuffer
+    call StringLength
+    ld b, a
+    ld hl, LinkTxBuffer
+    call LinkSendFrameWithCRC
+    jr c, .error
+    xor a
+    ret
+.error:
+    scf
+    ret
 
 LinkVerify:
-    call LinkReceiveByte, jr c, .error, cp LINK_VERIFY_REQ, jr nz, .error
-    ld a, LINK_VERIFY_ACK, call LinkSendByte, jr c, .error, xor a, ret
-.error: scf, ret
+    call LinkReceiveByte
+    jr c, .error
+    cp LINK_VERIFY_REQ
+    jr nz, .error
+    ld a, LINK_VERIFY_ACK
+    call LinkSendByte
+    jr c, .error
+    xor a
+    ret
+.error:
+    scf
+    ret
 
 LinkClose:
-    xor a, ld [rSB], a, ld [rSC], a, ret
+    xor a
+    ld [rSB], a
+    ld [rSC], a
+    ret
 
 ; --- Lógica de Frames y Bajo Nivel ---
 LinkSendFrameWithCRC:
-    push bc, ld a, b, call CalculateCRC8, ld [FrameCRC], a, pop bc
-    ld a, LINK_START_BYTE, call LinkSendByte, jr c, .send_error
-    ld a, b, call LinkSendByte, jr c, .send_error
-.data_loop: or b, jr z, .data_done
-    ld a, [hl+], call LinkSendByte, jr c, .send_error, dec b, jr .data_loop
+    push bc
+    ld a, b
+    call CalculateCRC8
+    ld [FrameCRC], a
+    pop bc
+    ld a, LINK_START_BYTE
+    call LinkSendByte
+    jr c, .send_error
+    ld a, b
+    call LinkSendByte
+    jr c, .send_error
+.data_loop:
+    or b
+    jr z, .data_done
+    ld a, [hl+]
+    call LinkSendByte
+    jr c, .send_error
+    dec b
+    jr .data_loop
 .data_done:
-    ld a, [FrameCRC], call LinkSendByte, jr c, .send_error
-    ld a, LINK_END_BYTE, call LinkSendByte, jr c, .send_error
-    call LinkReceiveByte, jr c, .send_error
-    cp LINK_FRAME_ACK, jr z, .success_frame, scf, ret
-.success_frame: xor a, ret, .send_error: scf, ret
+    ld a, [FrameCRC]
+    call LinkSendByte
+    jr c, .send_error
+    ld a, LINK_END_BYTE
+    call LinkSendByte
+    jr c, .send_error
+    call LinkReceiveByte
+    jr c, .send_error
+    cp LINK_FRAME_ACK
+    jr z, .success_frame
+    scf
+    ret
+.success_frame:
+    xor a
+    ret
+.send_error:
+    scf
+    ret
 
 BuildTransactionPayload:
-    ld hl, AddressBuf, ld de, LinkTxBuffer, ld bc, WALLET_ADDR_LEN, call CopyString
-    ld hl, LinkTxBuffer, call StringLength, ld c, a
-    ld a, '|', ld [de+], a
-    ld hl, AmountBuf, ld a, LINK_MAX_PAYLOAD, sub c, dec a, ld b, 0, ld c, a
-    call CopyString, jr c, .build_error, xor a, ret
-.build_error: scf, ret
+    ld hl, AddressBuf
+    ld de, LinkTxBuffer
+    ld bc, WALLET_ADDR_LEN
+    call CopyString
+    ld hl, LinkTxBuffer
+    call StringLength
+    ld c, a
+    ld a, '|'
+    ld [de+], a
+    ld hl, AmountBuf
+    ld a, LINK_MAX_PAYLOAD
+    sub c
+    dec a
+    ld b, 0
+    ld c, a
+    call CopyString
+    jr c, .build_error
+    xor a
+    ret
+.build_error:
+    scf
+    ret
 
 CalculateCRC8:
-    ld c, 0, ld d, b
-.byte_loop: ld a, d, or a, jr z, .crc_done
-    ld a, [hl+], xor c, ld c, a, ld e, 8
-.bit_loop: sla c, jr nc, .no_xor, ld a, c, xor $07, ld c, a
-.no_xor: dec e, jr nz, .bit_loop, dec d, jr .byte_loop
-.crc_done: ld a, c, ret
+    ld c, 0
+    ld d, b
+.byte_loop:
+    ld a, d
+    or a
+    jr z, .crc_done
+    ld a, [hl+]
+    xor c
+    ld c, a
+    ld e, 8
+.bit_loop:
+    sla c
+    jr nc, .no_xor
+    ld a, c
+    xor $07
+    ld c, a
+.no_xor:
+    dec e
+    jr nz, .bit_loop
+    dec d
+    jr .byte_loop
+.crc_done:
+    ld a, c
+    ret
 
 LinkSendByte:
-    ld [rSB], a, ld a, $81, ld [rSC], a, ld bc, TIMEOUT_SHORT
-.wait_send: ld a, [rSC], bit 7, a, jr z, .send_ok
-    dec bc, ld a, b, or c, jr nz, .wait_send, scf, ret
-.send_ok: xor a, ret
+    ld [rSB], a
+    ld a, $81
+    ld [rSC], a
+    ld bc, TIMEOUT_SHORT
+.wait_send:
+    ld a, [rSC]
+    bit 7, a
+    jr z, .send_ok
+    dec bc
+    ld a, b
+    or c
+    jr nz, .wait_send
+    scf
+    ret
+.send_ok:
+    xor a
+    ret
 
 LinkReceiveByte:
     ld bc, TIMEOUT_LONG
-.wait_recv: ld a, [rSC], bit 7, a, jr z, .recv_ok
-    dec bc, ld a, b, or c, jr nz, .wait_recv, scf, ret
-.recv_ok: ld a, [rSB], or a, ret
+.wait_recv:
+    ld a, [rSC]
+    bit 7, a
+    jr z, .recv_ok
+    dec bc
+    ld a, b
+    or c
+    jr nz, .wait_recv
+    scf
+    ret
+.recv_ok:
+    ld a, [rSB]
+    or a
+    ret
 
 ; ====================================================================
 ; UI y Strings
@@ -145,9 +319,21 @@ LinkTitle:         DB "CABLE LINK",0
 .no_data_msg:      DB "No hay datos para enviar.",0
 
 DrawLinkScreen:
-    call UI_ClearScreen, ld a, 1, ld b, 1, ld c, 18, ld d, 16, call UI_DrawBox
-    ld hl, LinkTitle, ld c, 1, ld d, 1, ld e, 18, call UI_PrintInBox
-    ld d, 8, ld e, 2, call UI_PrintStringAtXY, ret
+    call UI_ClearScreen
+    ld a, 1
+    ld b, 1
+    ld c, 18
+    ld d, 16
+    call UI_DrawBox
+    ld hl, LinkTitle
+    ld c, 1
+    ld d, 1
+    ld e, 18
+    call UI_PrintInBox
+    ld d, 8
+    ld e, 2
+    call UI_PrintStringAtXY
+    ret
 
 ; --- Variables WRAM ---
 SECTION "LinkVars", WRAM0[$CD00]

--- a/src/main.asm
+++ b/src/main.asm
@@ -46,24 +46,48 @@ MainLoop:
 .read_input_loop:
     call ReadJoypadWithDebounce
     ld a, [JoyState]
-    bit BUTTON_UP_BIT, a,   jr nz, .move_up
-    bit BUTTON_DOWN_BIT, a, jr nz, .move_down
-    bit BUTTON_A_BIT, a,    jr nz, .select_item
+    bit BUTTON_UP_BIT, a
+    jr nz, .move_up
+    bit BUTTON_DOWN_BIT, a
+    jr nz, .move_down
+    bit BUTTON_A_BIT, a
+    jr nz, .select_item
     jr .read_input_loop
 
 .move_up:
-    ld a, [CursorIndex], or a, jr z, .read_input_loop
-    dec a, ld [CursorIndex], a, call PlayBeepNav, jp MainLoop
+    ld a, [CursorIndex]
+    or a
+    jr z, .read_input_loop
+    dec a
+    ld [CursorIndex], a
+    call PlayBeepNav
+    jp MainLoop
 .move_down:
-    ld a, [CursorIndex], cp MENU_ITEMS - 1, jr z, .read_input_loop
-    inc a, ld [CursorIndex], a, call PlayBeepNav, jp MainLoop
+    ld a, [CursorIndex]
+    cp MENU_ITEMS - 1
+    jr z, .read_input_loop
+    inc a
+    ld [CursorIndex], a
+    call PlayBeepNav
+    jp MainLoop
 
 .select_item:
     call PlayBeepConfirm
-    ld a, ENTRY_NEW, ld [EntryReason], a
-    ld a, 1, call SwitchBank
-    ld a, [CursorIndex], ld c, a, ld b, 0, ld hl, EntryPoints, add hl, bc, add hl, bc
-    ld e, [hl], inc hl, ld d, [hl], push de, ret
+    ld a, ENTRY_NEW
+    ld [EntryReason], a
+    ld a, 1
+    call SwitchBank
+    ld a, [CursorIndex]
+    ld c, a
+    ld b, 0
+    ld hl, EntryPoints
+    add hl, bc
+    add hl, bc
+    ld e, [hl]
+    inc hl
+    ld d, [hl]
+    push de
+    ret
 
 ; --- Rutinas de Inicialización ---
 InitGlobalVars:
@@ -82,65 +106,150 @@ InitSubsystems:
     ret
 
 InitInterrupts:
-    di, xor a, ld [rIF], a, ld a, (1 << IEF_VBLANK), ld [rIE], a, ei, ret
+    di
+    xor a
+    ld [rIF], a
+    ld a, (1 << IEF_VBLANK)
+    ld [rIE], a
+    ei
+    ret
 
 InitVRAM:
     push af, bc, hl
     call WaitVBlank
-    xor a, ld [rLCDC], a
-    ld hl, $8000, ld bc, $1800, call FillMemory
+    xor a
+    ld [rLCDC], a
+    ld hl, $8000
+    ld bc, $1800
+    call FillMemory
     call LoadFont
-    ld a, %11100100, ld [rBGP], a
-    ld a, LCDCF_ON | LCDCF_BG8000 | LCDCF_BG9800 | LCDCF_BGON, ld [rLCDC], a
-    pop hl, bc, af, ret
+    ld a, %11100100
+    ld [rBGP], a
+    ld a, LCDCF_ON | LCDCF_BG8000 | LCDCF_BG9800 | LCDCF_BGON
+    ld [rLCDC], a
+    pop hl, bc, af
+    ret
 
 LoadFont:
     push af, bc, de, hl
-    ld hl, FontData, ld de, $8000 + (" " * 16), ld bc, 96 * 16, call CopyString
-    pop hl, de, bc, af, ret
+    ld hl, FontData
+    ld de, $8000 + (" " * 16)
+    ld bc, 96 * 16
+    call CopyString
+    pop hl, de, bc, af
+    ret
 
 ; --- Flujo y UI ---
 VBlankHandler:
     push af, bc, de, hl
-    ld a, [FrameCounter], inc a, ld [FrameCounter], a
+    ld a, [FrameCounter]
+    inc a
+    ld [FrameCounter], a
     ; Sound_Update podría ir aquí
-    pop hl, de, bc, af, reti
+    pop hl, de, bc, af
+    reti
 
 SwitchBank:
-    ld [CurrentBank], a, ld [$2000], a, ret
+    ld [CurrentBank], a
+    ld [$2000], a
+    ret
 
 ExitGame:
-    call SRAM_Init, xor a, ld [rNR52], a, jp $0000
+    call SRAM_Init
+    xor a
+    ld [rNR52], a
+    jp $0000
 
 ShowWarning:
     push af, bc, de, hl
-    call UI_ClearScreen, ld a, 2, ld b, 4, ld c, 16, ld d, 10, call UI_DrawBox
-    ld hl, WarningTitle, ld c, 2, ld d, 4, ld e, 16, call UI_PrintInBox
-    ld hl, WarningMsg1, ld d, 7, ld e, 4, call UI_PrintStringAtXY
-    ld hl, WarningMsg2, ld d, 8, ld e, 4, call UI_PrintStringAtXY
-    ld hl, WarningMsg3, ld d, 9, ld e, 4, call UI_PrintStringAtXY
-    ld hl, WarningPress, ld d, 12, ld e, 6, call UI_PrintStringAtXY
-    ld a, (1 << BUTTON_A_BIT), call WaitButton, call PlayBeepConfirm
-    pop hl, de, bc, af, ret
+    call UI_ClearScreen
+    ld a, 2
+    ld b, 4
+    ld c, 16
+    ld d, 10
+    call UI_DrawBox
+    ld hl, WarningTitle
+    ld c, 2
+    ld d, 4
+    ld e, 16
+    call UI_PrintInBox
+    ld hl, WarningMsg1
+    ld d, 7
+    ld e, 4
+    call UI_PrintStringAtXY
+    ld hl, WarningMsg2
+    ld d, 8
+    ld e, 4
+    call UI_PrintStringAtXY
+    ld hl, WarningMsg3
+    ld d, 9
+    ld e, 4
+    call UI_PrintStringAtXY
+    ld hl, WarningPress
+    ld d, 12
+    ld e, 6
+    call UI_PrintStringAtXY
+    ld a, (1 << BUTTON_A_BIT)
+    call WaitButton
+    call PlayBeepConfirm
+    pop hl, de, bc, af
+    ret
 
 DrawMenu:
     push af, bc, de, hl
-    call UI_ClearScreen, ld a, 1, ld b, 1, ld c, 18, ld d, 16, call UI_DrawBox
-    ld hl, MenuTitle, ld c, 1, ld d, 1, ld e, 18, call UI_PrintInBox
+    call UI_ClearScreen
+    ld a, 1
+    ld b, 1
+    ld c, 18
+    ld d, 16
+    call UI_DrawBox
+    ld hl, MenuTitle
+    ld c, 1
+    ld d, 1
+    ld e, 18
+    call UI_PrintInBox
     ld b, 0
 .draw_items_loop:
-    ld a, b, cp MENU_ITEMS, jr z, .draw_instr
-    push bc, push hl, ld a, b, add a, add 4, ld d, a
-    ld a, [CursorIndex], cp b, jr nz, .no_cursor
-    ld a, '>', ld e, 2, call UI_PrintAtXY
+    ld a, b
+    cp MENU_ITEMS
+    jr z, .draw_instr
+    push bc
+    push hl
+    ld a, b
+    add a
+    add 4
+    ld d, a
+    ld a, [CursorIndex]
+    cp b
+    jr nz, .no_cursor
+    ld a, '>'
+    ld e, 2
+    call UI_PrintAtXY
 .no_cursor:
-    ld hl, MenuPtrs, ld a, b, ld c, b, ld b, 0, add hl, bc, add hl, bc
-    ld e, [hl], inc hl, ld d, [hl], ex de, hl
-    ld d, [sp], ld e, 4, call UI_PrintStringAtXY
-    pop hl, pop bc, inc b, jr .draw_items_loop
+    ld hl, MenuPtrs
+    ld a, b
+    ld c, b
+    ld b, 0
+    add hl, bc
+    add hl, bc
+    ld e, [hl]
+    inc hl
+    ld d, [hl]
+    ex de, hl
+    ld d, [sp]
+    ld e, 4
+    call UI_PrintStringAtXY
+    pop hl
+    pop bc
+    inc b
+    jr .draw_items_loop
 .draw_instr:
-    ld hl, MenuInstr, ld d, 15, ld e, 2, call UI_PrintStringAtXY
-    pop hl, de, bc, af, ret
+    ld hl, MenuInstr
+    ld d, 15
+    ld e, 2
+    call UI_PrintStringAtXY
+    pop hl, de, bc, af
+    ret
 
 ; ====================================================================
 ; Variables Globales y Buffers Compartidos

--- a/src/printer.asm
+++ b/src/printer.asm
@@ -36,76 +36,225 @@ PrinterResponse:    DS 16, PrintBuffer: DS QR_TILES_WIDTH * QR_TILES_HEIGHT * 16
 SECTION "PrinterModule", ROM1[$5800]
 
 Entry_Printer:
-    ld hl, AddressBuf, ld a, [hl], or a, jr z, .no_data
-    call DrawPrinterScreen, .preparing
-    call InitPrinterComm, jr c, .comm_error
+    ld hl, AddressBuf
+    ld a, [hl]
+    or a
+    jr z, .no_data
+    ld hl, .preparing
+    call DrawPrinterScreen
+    call InitPrinterComm
+    jr c, .comm_error
     call PrepareQRPrintBuffer
-    call PrinterSendInit, jr c, .comm_error
-    call PrinterSendData, jr c, .comm_error
-    call PrinterSendPrint, jr c, .comm_error
-    call DrawPrinterScreen, .success_msg, call PlayBeepConfirm, jr .wait_exit
+    call PrinterSendInit
+    jr c, .comm_error
+    call PrinterSendData
+    jr c, .comm_error
+    call PrinterSendPrint
+    jr c, .comm_error
+    ld hl, .success_msg
+    call DrawPrinterScreen
+    call PlayBeepConfirm
+    jr .wait_exit
 .comm_error:
-    call DrawPrinterScreen, .error_msg, call PlayBeepError
+    ld hl, .error_msg
+    call DrawPrinterScreen
+    call PlayBeepError
 .wait_exit:
-    ld a, (1 << BUTTON_B_BIT), call WaitButton, ret
+    ld a, (1 << BUTTON_B_BIT)
+    call WaitButton
+    ret
 .no_data:
-    call DrawPrinterScreen, .no_data_msg, ld a, (1 << BUTTON_B_BIT), call WaitButton, ret
+    ld hl, .no_data_msg
+    call DrawPrinterScreen
+    ld a, (1 << BUTTON_B_BIT)
+    call WaitButton
+    ret
 
 ; ====================================================================
 ; Lógica del Protocolo (Conceptualizado como una librería interna)
 ; ====================================================================
-InitPrinterComm: xor a, ld [rSB], a, ld a, $80, ld [rSC], a, call GetPrinterStatus, cp PRINTER_READY, ret
+InitPrinterComm:
+    xor a
+    ld [rSB], a
+    ld a, $80
+    ld [rSC], a
+    call GetPrinterStatus
+    cp PRINTER_READY
+    ret
 GetPrinterStatus:
-    ld hl, PrinterPacket, ld a, PRINTER_SYNC_1, ld [hl+], a, ld a, PRINTER_SYNC_2, ld [hl+], a
-    ld a, PRINTER_STATUS, ld [hl+], a, xor a, ld [hl+], a, ld [hl+], a, ld [hl+], a
-    ld hl, PrinterPacket + 2, ld bc, 4, call CalculateChecksum, ld hl, PrinterPacket + 6, ld [hl+], c, ld [hl], b
-    ld hl, PrinterPacket, ld bc, 8, call SendToPrinter, jr c, .status_error
-    ld bc, 6, ld de, PrinterResponse, call ReceiveFromPrinter, jr c, .status_error
-    ld a, [PrinterResponse], cp PRINTER_SYNC_1, jr nz, .status_error, ld a, [PrinterResponse+1], cp PRINTER_SYNC_2, jr nz, .status_error
-    ld a, [PrinterResponse+4], and $F0, jr nz, .status_error
-    ld a, PRINTER_READY, or a, ret
-.status_error: ld a, PRINTER_ERROR, scf, ret
+    ld hl, PrinterPacket
+    ld a, PRINTER_SYNC_1
+    ld [hl+], a
+    ld a, PRINTER_SYNC_2
+    ld [hl+], a
+    ld a, PRINTER_STATUS
+    ld [hl+], a
+    xor a
+    ld [hl+], a
+    ld [hl+], a
+    ld [hl+], a
+    ld hl, PrinterPacket + 2
+    ld bc, 4
+    call CalculateChecksum
+    ld hl, PrinterPacket + 6
+    ld [hl+], c
+    ld [hl], b
+    ld hl, PrinterPacket
+    ld bc, 8
+    call SendToPrinter
+    jr c, .status_error
+    ld bc, 6
+    ld de, PrinterResponse
+    call ReceiveFromPrinter
+    jr c, .status_error
+    ld a, [PrinterResponse]
+    cp PRINTER_SYNC_1
+    jr nz, .status_error
+    ld a, [PrinterResponse+1]
+    cp PRINTER_SYNC_2
+    jr nz, .status_error
+    ld a, [PrinterResponse+4]
+    and $F0
+    jr nz, .status_error
+    ld a, PRINTER_READY
+    or a
+    ret
+.status_error:
+    ld a, PRINTER_ERROR
+    scf
+    ret
 
 SendToPrinter:
-.loop: ld a, b, or c, ret z, ld a, [hl+], call SendByte, jr c, .error, dec bc, jr .loop
-.error: scf, ret
+.loop:
+    ld a, b
+    or c
+    ret z
+    ld a, [hl+]
+    call SendByte
+    jr c, .error
+    dec bc
+    jr .loop
+.error:
+    scf
+    ret
 
 ReceiveFromPrinter:
-    ld h, d, ld l, e
-.loop_r: ld a, b, or c, ret z, call ReceiveByte, jr c, .error_r, ld [hl+], a, dec bc, jr .loop_r
-.error_r: scf, ret
+    ld h, d
+    ld l, e
+.loop_r:
+    ld a, b
+    or c
+    ret z
+    call ReceiveByte
+    jr c, .error_r
+    ld [hl+], a
+    dec bc
+    jr .loop_r
+.error_r:
+    scf
+    ret
 
 SendByte:
-    ld [rSB], a, ld a, $81, ld [rSC], a, ld bc, PRINTER_TIMEOUT
-.wait_s: ld a, [rSC], bit 7, a, jr z, .ok_s, dec bc, ld a, b, or c, jr nz, .wait_s, scf, ret
-.ok_s: xor a, ret
+    ld [rSB], a
+    ld a, $81
+    ld [rSC], a
+    ld bc, PRINTER_TIMEOUT
+.wait_s:
+    ld a, [rSC]
+    bit 7, a
+    jr z, .ok_s
+    dec bc
+    ld a, b
+    or c
+    jr nz, .wait_s
+    scf
+    ret
+.ok_s:
+    xor a
+    ret
 
 ReceiveByte:
     ld bc, PRINTER_TIMEOUT
-.wait_r: ld a, [rSC], bit 7, a, jr z, .ok_r, dec bc, ld a, b, or c, jr nz, .wait_r, scf, ret
-.ok_r: ld a, [rSB], or a, ret
+.wait_r:
+    ld a, [rSC]
+    bit 7, a
+    jr z, .ok_r
+    dec bc
+    ld a, b
+    or c
+    jr nz, .wait_r
+    scf
+    ret
+.ok_r:
+    ld a, [rSB]
+    or a
+    ret
 
 CalculateChecksum:
     ld de, 0
-.loop_c: ld a, b, or c, jr z, .done_c, ld a, [hl+], add e, ld e, a, ld a, d, adc 0, ld d, a, dec bc, jr .loop_c
-.done_c: ld b, d, ld c, e, ret
+.loop_c:
+    ld a, b
+    or c
+    jr z, .done_c
+    ld a, [hl+]
+    add e
+    ld e, a
+    ld a, d
+    adc 0
+    ld d, a
+    dec bc
+    jr .loop_c
+.done_c:
+    ld b, d
+    ld c, e
+    ret
 
 PrinterSendInit:
     ; ... (Lógica de construcción de paquete Init, idéntica a GetPrinterStatus pero con comando PRINTER_INIT)
     ; Por brevedad, se omite el código idéntico. Retorna carry en error.
 
 PrepareQRPrintBuffer:
-    ld hl, PrintBuffer, ld bc, QR_TILES_WIDTH * QR_TILES_HEIGHT * 16, xor a, call FillMemory, call ConvertQRToTiles, ret
+    ld hl, PrintBuffer
+    ld bc, QR_TILES_WIDTH * QR_TILES_HEIGHT * 16
+    xor a
+    call FillMemory
+    call ConvertQRToTiles
+    ret
 ConvertQRToTiles:
     ld b, 0
-.row_loop: ld c, 0
+.row_loop:
+    ld c, 0
 .col_loop:
-    push bc, ld h, 0, ld l, b, ld de, QR_SIZE, call MultiplyHLByDE, ld a, l, add c, ld l, a, ld a, h, adc 0, ld h, a
-    ld de, QR_Matrix, add hl, de, ld a, [hl]
-    pop bc, or a, jr z, .skip_pixel
-    push bc, call DrawQRPixelBlock, pop bc
-.skip_pixel: inc c, ld a, c, cp QR_SIZE, jr c, .col_loop
-    inc b, ld a, b, cp QR_SIZE, jr c, .row_loop, ret
+    push bc
+    ld h, 0
+    ld l, b
+    ld de, QR_SIZE
+    call MultiplyHLByDE
+    ld a, l
+    add c
+    ld l, a
+    ld a, h
+    adc 0
+    ld h, a
+    ld de, QR_Matrix
+    add hl, de
+    ld a, [hl]
+    pop bc
+    or a
+    jr z, .skip_pixel
+    push bc
+    call DrawQRPixelBlock
+    pop bc
+.skip_pixel:
+    inc c
+    ld a, c
+    cp QR_SIZE
+    jr c, .col_loop
+    inc b
+    ld a, b
+    cp QR_SIZE
+    jr c, .row_loop
+    ret
 DrawQRPixelBlock:
     ; ... (sin cambios)
 PrinterSendData:
@@ -114,13 +263,33 @@ PrinterSendPrint:
     ; ... (sin cambios, es lógica compleja específica del protocolo)
 
 MultiplyHLByDE:
-    ld b, h, ld c, l, ld hl, 0
-.mult_loop: ld a, d, or e, ret z, add hl, bc, dec de, jr .mult_loop
+    ld b, h
+    ld c, l
+    ld hl, 0
+.mult_loop:
+    ld a, d
+    or e
+    ret z
+    add hl, bc
+    dec de
+    jr .mult_loop
 
 ; ====================================================================
 ; UI
 ; ====================================================================
 DrawPrinterScreen:
-    call UI_ClearScreen, ld a, 1, ld b, 1, ld c, 18, ld d, 16, call UI_DrawBox
-    ld hl, PrinterTitle, ld c, 1, ld d, 1, ld e, 18, call UI_PrintInBox
-    ld d, 8, ld e, 3, call UI_PrintStringAtXY, ret
+    call UI_ClearScreen
+    ld a, 1
+    ld b, 1
+    ld c, 18
+    ld d, 16
+    call UI_DrawBox
+    ld hl, PrinterTitle
+    ld c, 1
+    ld d, 1
+    ld e, 18
+    call UI_PrintInBox
+    ld d, 8
+    ld e, 3
+    call UI_PrintStringAtXY
+    ret

--- a/src/sram.asm
+++ b/src/sram.asm
@@ -44,118 +44,312 @@ MsgCreated:          DB "Wallet creado.",0, MsgDeleted: DB "Wallet eliminado.",0
 SECTION "SramMenuCode", ROM1
 
 Entry_SRAM:
-    xor a, ld [sram_menu_cursor_pos], a
+    xor a
+    ld [sram_menu_cursor_pos], a
 .loop_menu:
-    call DrawSramMenu, call ReadJoypadWithDebounce
+    call DrawSramMenu
+    call ReadJoypadWithDebounce
     ld a, [JoyState]
-    bit BUTTON_UP_BIT, a,   jr nz, .move_up
-    bit BUTTON_DOWN_BIT, a, jr nz, .move_down
-    bit BUTTON_A_BIT, a,    jr nz, .select_option
-    bit BUTTON_B_BIT, a,    ret
+    bit BUTTON_UP_BIT, a
+    jr nz, .move_up
+    bit BUTTON_DOWN_BIT, a
+    jr nz, .move_down
+    bit BUTTON_A_BIT, a
+    jr nz, .select_option
+    bit BUTTON_B_BIT, a
+    ret
     jr .loop_menu
 
 .move_up:
-    ld a, [sram_menu_cursor_pos], or a, jr z, .wrap_bottom, dec a, jr .update_cursor
+    ld a, [sram_menu_cursor_pos]
+    or a
+    jr z, .wrap_bottom
+    dec a
+    jr .update_cursor
 .wrap_bottom: ld a, SRAM_MENU_ITEMS - 1
-.update_cursor: ld [sram_menu_cursor_pos], a, call PlayBeepNav, jr .loop_menu
+.update_cursor:
+    ld [sram_menu_cursor_pos], a
+    call PlayBeepNav
+    jr .loop_menu
 
 .move_down:
-    ld a, [sram_menu_cursor_pos], inc a, cp SRAM_MENU_ITEMS, jr c, .update_cursor, xor a, jr .update_cursor
+    ld a, [sram_menu_cursor_pos]
+    inc a
+    cp SRAM_MENU_ITEMS
+    jr c, .update_cursor
+    xor a
+    jr .update_cursor
 
 .select_option:
-    call PlayBeepConfirm, ld a, [sram_menu_cursor_pos]
-    cp 0, jp z, CreateWalletFlow
-    cp 1, jp z, SelectWalletFlow
-    cp 2, jp z, DeleteWalletFlow
+    call PlayBeepConfirm
+    ld a, [sram_menu_cursor_pos]
+    cp 0
+    jp z, CreateWalletFlow
+    cp 1
+    jp z, SelectWalletFlow
+    cp 2
+    jp z, DeleteWalletFlow
     ret
 
 ; ====================================================================
 ; Flujos de Lógica: Crear, Seleccionar, Borrar
 ; ====================================================================
 CreateWalletFlow:
-    call SRAM_GetWalletCount, cp MAX_WALLETS, jr nc, .limit_error
-    call GetText, CreateNamePrompt, NewWalletNameBuffer, WALLET_NAME_LEN
-    call GetText, CreateAddrPrompt, NewWalletAddrBuffer, WALLET_ADDR_LEN
-    ld hl, NewWalletNameBuffer, ld de, WALLET_NAME, ld bc, WALLET_NAME_LEN, call CopyString
-    ld hl, NewWalletAddrBuffer, ld de, WALLET_ADDR, ld bc, WALLET_ADDR_LEN, call CopyString
-    call SRAM_CreateWallet, call ShowMessage, MsgCreated, jp Entry_SRAM
-.limit_error: call ShowMessage, LimitErrorMsg, jp Entry_SRAM
+    call SRAM_GetWalletCount
+    cp MAX_WALLETS
+    jr nc, .limit_error
+    ld hl, CreateNamePrompt
+    ld de, NewWalletNameBuffer
+    ld c, WALLET_NAME_LEN
+    call GetText
+    ld hl, CreateAddrPrompt
+    ld de, NewWalletAddrBuffer
+    ld c, WALLET_ADDR_LEN
+    call GetText
+    ld hl, NewWalletNameBuffer
+    ld de, WALLET_NAME
+    ld bc, WALLET_NAME_LEN
+    call CopyString
+    ld hl, NewWalletAddrBuffer
+    ld de, WALLET_ADDR
+    ld bc, WALLET_ADDR_LEN
+    call CopyString
+    call SRAM_CreateWallet
+    ld hl, MsgCreated
+    call ShowMessage
+    jp Entry_SRAM
+.limit_error:
+    ld hl, LimitErrorMsg
+    call ShowMessage
+    jp Entry_SRAM
 
-SelectWalletFlow: ld a, LIST_MODE_SELECT, call WalletList_Show, jp Entry_SRAM
-DeleteWalletFlow: ld a, LIST_MODE_DELETE, call WalletList_Show, jp Entry_SRAM
+SelectWalletFlow:
+    ld a, LIST_MODE_SELECT
+    call WalletList_Show
+    jp Entry_SRAM
+DeleteWalletFlow:
+    ld a, LIST_MODE_DELETE
+    call WalletList_Show
+    jp Entry_SRAM
 
 WalletList_Show:
-    ld [sram_list_mode], a, call SRAM_GetWalletCount, or a, jr z, .no_wallets, ld [sram_wallet_count], a
-    ld b, 0, ld c, a, ld hl, sram_wallet_names_buffer
+    ld [sram_list_mode], a
+    call SRAM_GetWalletCount
+    or a
+    jr z, .no_wallets
+    ld [sram_wallet_count], a
+    ld b, 0
+    ld c, a
+    ld hl, sram_wallet_names_buffer
 .load_loop:
-    ld a, b, cp c, jr z, .loaded
-    push hl, push bc, ld a, b, call SRAM_LoadWallet, pop bc, pop hl, ld de, WALLET_NAME
-.copy_name: ld a, [de+], ld [hl+], a, or a, jr nz, .copy_name
-    inc b, jr .load_loop
+    ld a, b
+    cp c
+    jr z, .loaded
+    push hl
+    push bc
+    ld a, b
+    call SRAM_LoadWallet
+    pop bc
+    pop hl
+    ld de, WALLET_NAME
+.copy_name:
+    ld a, [de+]
+    ld [hl+], a
+    or a
+    jr nz, .copy_name
+    inc b
+    jr .load_loop
 .loaded:
-    xor a, ld [sram_list_cursor_pos], a
+    xor a
+    ld [sram_list_cursor_pos], a
 .list_loop:
-    call DrawWalletList, call ReadJoypadWithDebounce, ld a, [JoyState]
-    bit BUTTON_UP_BIT, a, jr nz, .list_up, bit BUTTON_DOWN_BIT, a, jr nz, .list_down
-    bit BUTTON_A_BIT, a, jr nz, .list_select, bit BUTTON_B_BIT, a, jr z, .list_loop, ret
+    call DrawWalletList
+    call ReadJoypadWithDebounce
+    ld a, [JoyState]
+    bit BUTTON_UP_BIT, a
+    jr nz, .list_up
+    bit BUTTON_DOWN_BIT, a
+    jr nz, .list_down
+    bit BUTTON_A_BIT, a
+    jr nz, .list_select
+    bit BUTTON_B_BIT, a
+    jr z, .list_loop
+    ret
 
-.no_wallets: call ShowMessage, NoWalletsMsg, ret
+.no_wallets:
+    ld hl, NoWalletsMsg
+    call ShowMessage
+    ret
 .list_up:
-    ld a, [sram_list_cursor_pos], or a, jr z, .list_wrap_bot, dec a, jr .list_upd
+    ld a, [sram_list_cursor_pos]
+    or a
+    jr z, .list_wrap_bot
+    dec a
+    jr .list_upd
 .list_wrap_bot: ld a, [sram_wallet_count], dec a
-.list_upd: ld [sram_list_cursor_pos], a, call PlayBeepNav, jr .list_loop
+.list_upd:
+    ld [sram_list_cursor_pos], a
+    call PlayBeepNav
+    jr .list_loop
 .list_down:
-    ld a, [sram_list_cursor_pos], inc a, ld b, a, ld a, [sram_wallet_count], cp b, jr c, .list_upd, xor a, jr .list_upd
+    ld a, [sram_list_cursor_pos]
+    inc a
+    ld b, a
+    ld a, [sram_wallet_count]
+    cp b
+    jr c, .list_upd
+    xor a
+    jr .list_upd
 .list_select:
-    call PlayBeepConfirm, ld a, [sram_list_mode], cp LIST_MODE_DELETE, jr z, .delete_wallet
-    ld a, [sram_list_cursor_pos], call SRAM_LoadWallet, call ShowMessage, MsgSelected, ret
+    call PlayBeepConfirm
+    ld a, [sram_list_mode]
+    cp LIST_MODE_DELETE
+    jr z, .delete_wallet
+    ld a, [sram_list_cursor_pos]
+    call SRAM_LoadWallet
+    ld hl, MsgSelected
+    call ShowMessage
+    ret
 .delete_wallet:
-    call ConfirmDelete, or a, jr z, .list_loop, ld a, [sram_list_cursor_pos], call SRAM_DeleteWallet, call ShowMessage, MsgDeleted, ret
+    call ConfirmDelete
+    or a
+    jr z, .list_loop
+    ld a, [sram_list_cursor_pos]
+    call SRAM_DeleteWallet
+    ld hl, MsgDeleted
+    call ShowMessage
+    ret
 
 ; ====================================================================
 ; Subrutinas y UI
 ; ====================================================================
 GetText: ; Entrada: HL=Prompt, DE=DestBuffer, C=MaxLen
-    push de, push bc
-    ld a, h, ld [InputPromptAddr+1], a, ld a, l, ld [InputPromptAddr], a
-    ld a, e, ld [InputDestBufAddr+1], a, ld a, d, ld [InputDestBufAddr], a
-    pop af, ld [InputMaxLen], a
-    call Entry_Input, pop de, pop bc, ret
+    push de
+    push bc
+    ld a, h
+    ld [InputPromptAddr+1], a
+    ld a, l
+    ld [InputPromptAddr], a
+    ld a, e
+    ld [InputDestBufAddr+1], a
+    ld a, d
+    ld [InputDestBufAddr], a
+    pop af
+    ld [InputMaxLen], a
+    call Entry_Input
+    pop de
+    pop bc
+    ret
 
 DrawSramMenu:
-    call UI_ClearScreen, ld hl, SramMenuTitle, ld d, 2, ld e, 2, call UI_PrintStringAtXY
-    ld hl, MenuOptionCreate, ld d, 5, ld e, 3, call DrawMenuItem, 0
-    ld hl, MenuOptionSelect, ld d, 6, ld e, 3, call DrawMenuItem, 1
-    ld hl, MenuOptionDelete, ld d, 7, ld e, 3, call DrawMenuItem, 2
-    ld hl, MenuOptionBack,   ld d, 8, ld e, 3, call DrawMenuItem, 3, ret
+    call UI_ClearScreen
+    ld hl, SramMenuTitle
+    ld d, 2
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld hl, MenuOptionCreate
+    ld d, 5
+    ld e, 3
+    ld a, 0
+    call DrawMenuItem
+    ld hl, MenuOptionSelect
+    ld d, 6
+    ld e, 3
+    ld a, 1
+    call DrawMenuItem
+    ld hl, MenuOptionDelete
+    ld d, 7
+    ld e, 3
+    ld a, 2
+    call DrawMenuItem
+    ld hl, MenuOptionBack
+    ld d, 8
+    ld e, 3
+    ld a, 3
+    call DrawMenuItem
+    ret
 DrawMenuItem:
-    push af, ld a, [sram_menu_cursor_pos], cp [sp+2], jr nz, .no_cursor
-    ld a, '>', ld b, e, dec b, push de, ld e, b, call UI_PrintAtXY, pop de
-.no_cursor: call UI_PrintStringAtXY, pop af, ret
+    push af
+    ld a, [sram_menu_cursor_pos]
+    cp [sp+2]
+    jr nz, .no_cursor
+    ld a, '>'
+    ld b, e
+    dec b
+    push de
+    ld e, b
+    call UI_PrintAtXY
+    pop de
+.no_cursor:
+    call UI_PrintStringAtXY
+    pop af
+    ret
 
 DrawWalletList:
-    call UI_ClearScreen, ld a, [sram_list_mode], or a, jr z, .title_select
-    ld hl, ListTitleDelete, jr .draw_title
-.title_select: ld hl, ListTitleSelect
+    call UI_ClearScreen
+    ld a, [sram_list_mode]
+    or a
+    jr z, .title_select
+    ld hl, ListTitleDelete
+    jr .draw_title
+.title_select:
+    ld hl, ListTitleSelect
 .draw_title:
-    ld d, 2, ld e, 2, call UI_PrintStringAtXY
-    ld c, [sram_wallet_count], ld hl, sram_wallet_names_buffer, xor b
+    ld d, 2
+    ld e, 2
+    call UI_PrintStringAtXY
+    ld c, [sram_wallet_count]
+    ld hl, sram_wallet_names_buffer
+    xor b
 .loop_draw:
-    ld a, b, cp c, jr z, .done_draw
-    push hl, ld a, b, add 5, ld d, a
-    ld a, [sram_list_cursor_pos], cp b, jr nz, .no_cursor_list
-    ld a, '>', ld e, 1, call UI_PrintAtXY
+    ld a, b
+    cp c
+    jr z, .done_draw
+    push hl
+    ld a, b
+    add 5
+    ld d, a
+    ld a, [sram_list_cursor_pos]
+    cp b
+    jr nz, .no_cursor_list
+    ld a, '>'
+    ld e, 1
+    call UI_PrintAtXY
 .no_cursor_list:
-    ld e, 3, call UI_PrintStringAtXY, pop hl
-.skip_name: ld a, [hl+], or a, jr nz, .skip_name
-    inc b, jr .loop_draw
-.done_draw: ret
+    ld e, 3
+    call UI_PrintStringAtXY
+    pop hl
+.skip_name:
+    ld a, [hl+]
+    or a
+    jr nz, .skip_name
+    inc b
+    jr .loop_draw
+.done_draw:
+    ret
 
 ConfirmDelete:
-    call ShowMessageNoWait, ConfirmDeletePrompt
+    ld hl, ConfirmDeletePrompt
+    call ShowMessageNoWait
 .wait_confirm:
-    call ReadJoypad, ld a, [JoyState], ld c, a, and (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT), cp c, jr z, .wait_confirm
-    ld a, [JoyState], bit BUTTON_A_BIT, a, ret
+    call ReadJoypad
+    ld a, [JoyState]
+    ld c, a
+    and (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT)
+    cp c
+    jr z, .wait_confirm
+    ld a, [JoyState]
+    bit BUTTON_A_BIT, a
+    ret
 
-ShowMessage: call ShowMessageNoWait, ld a, (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT), call WaitButton, ret
-ShowMessageNoWait: call UI_ClearScreen, ld d, 8, ld e, 3, call UI_PrintStringAtXY, ret
+ShowMessage:
+    call ShowMessageNoWait
+    ld a, (1 << BUTTON_A_BIT) | (1 << BUTTON_B_BIT)
+    call WaitButton
+    ret
+ShowMessageNoWait:
+    call UI_ClearScreen
+    ld d, 8
+    ld e, 3
+    call UI_PrintStringAtXY
+    ret


### PR DESCRIPTION
## Summary
- split multi-instruction lines so each instruction occupies its own line
- refactor main assembly modules accordingly

## Testing
- `make test` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_686133f80e8083218aa5a319e2dbbabf